### PR TITLE
Add website to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,5 +30,5 @@ ByteCompile: TRUE
 LazyData: TRUE
 Encoding: UTF-8
 RdMacros: mathjaxr
-URL: https://github.com/wviechtb/metadat
+URL: https://github.com/wviechtb/metadat, https://wviechtb.github.io/metadat/
 BugReports: https://github.com/wviechtb/metadat/issues


### PR DESCRIPTION
You may consider adding it in the About Section of the repo
![image](https://github.com/wviechtb/metadat/assets/52606734/ff458578-e570-479b-a754-9dcbcdac8b7e)
